### PR TITLE
포스트 검색 시, 페이지네이션 구현

### DIFF
--- a/src/main/java/com/example/backend_webflux/PostHandler.java
+++ b/src/main/java/com/example/backend_webflux/PostHandler.java
@@ -2,11 +2,17 @@ package com.example.backend_webflux;
 
 import static org.springframework.web.reactive.function.BodyInserters.fromValue;
 
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -69,5 +75,18 @@ public class PostHandler {
     Mono<Void> deleted = postRepository.deleteById(id);
 
     return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).body(deleted, Void.class);
+  }
+
+  public Mono<ServerResponse> getAllPostsPaging(ServerRequest request) {
+    Pageable pageable = PageRequest.of(0,3);
+
+    Flux<Post> pages = request
+        .queryParam("title")
+        .map(title -> postRepository.findByTitleContains(title, pageable))
+        .orElseGet(() -> postRepository.findAll());
+
+    return ServerResponse.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(pages, Post.class);
   }
 }

--- a/src/main/java/com/example/backend_webflux/PostRepository.java
+++ b/src/main/java/com/example/backend_webflux/PostRepository.java
@@ -1,9 +1,13 @@
 package com.example.backend_webflux;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 
 @Repository
 public interface PostRepository extends ReactiveMongoRepository<Post, Integer> {
+
+  Flux<Post> findByTitleContains(String title, Pageable pageable);
 
 }

--- a/src/main/java/com/example/backend_webflux/PostRouter.java
+++ b/src/main/java/com/example/backend_webflux/PostRouter.java
@@ -13,11 +13,12 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Configuration
 public class PostRouter {
+
   @Bean
   public RouterFunction<ServerResponse> routePost(PostHandler postHandler) {
     return RouterFunctions
         .route(GET("/api/post")
-            , postHandler::getAllPosts)
+            , postHandler::getAllPostsPaging)
         .andRoute(GET("/api/post/{id}")
             , postHandler::getPost)
         .andRoute(POST("/api/post")


### PR DESCRIPTION
## Description
ReactiveMongoRepository에서 제공하는 `findAll()` 의 return 타입은 `Flux`이다.
`findAll()`은 Pageable 인자를 사용할 수 없다.