### PR TITLE
[BUG] swagger-ui 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.1.2.RELEASE'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "org.springdoc.openapi-gradle-plugin" version "1.3.4"
     id 'java'
 }
 
@@ -24,7 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 //    implementation "io.springfox:springfox-boot-starter:3.0.0"
-    implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.4'
+    implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.9'
 
     compileOnly 'org.projectlombok:lombok'
 //    developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,15 @@ spring:
   data:
     mongodb:
       uri: mongodb://0.0.0.0:27017/ryoobibRepository
+server:
+  servlet:
+    context-path: /
+  compression:
+    enabled: true
+    mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
+    min-response-size: 1024
+  http2:
+    enabled: true
 com:
   example:
     backend_webflux:


### PR DESCRIPTION
## 문제 상황
 #3 
spring-reactive-monogodb 에서 관계 설정을 위해 @DBRef 어노테이션을 사용하고자 Spring framework 버전을 2.1.2.RELEASE로 낮춤.

변경 후, Swagger-ui에 spec 표시가 안됨.

## 해결 방안

build.gradle 파일에서 플러그인 설정 추가 및 swagger3 버전 변경 ( 가장 최신으로 ) 

yml 파일에서 별도의 설정 추가 ( 이게 의미가 있는 건지 모르겠음 )