### PR TITLE
[FIX] 몽고디비에서의 관계 설정 방식 변경

### DIFF
--- a/src/main/java/com/example/backend_webflux/domain/Comment.java
+++ b/src/main/java/com/example/backend_webflux/domain/Comment.java
@@ -15,8 +15,8 @@ public class Comment {
   private Integer id;
   private String content;
 
-  @DBRef
-  private User user;
-  @DBRef
-  private Post post;
+
+  private String user;
+
+  private String post;
 }

--- a/src/main/java/com/example/backend_webflux/domain/Post.java
+++ b/src/main/java/com/example/backend_webflux/domain/Post.java
@@ -16,7 +16,7 @@ public class Post {
   private String title;
   private String content;
   private Integer status;
-  @DBRef
-  private User user;
+
+  private String user;
 
 }

--- a/src/main/java/com/example/backend_webflux/domain/Scrap.java
+++ b/src/main/java/com/example/backend_webflux/domain/Scrap.java
@@ -15,10 +15,10 @@ public class Scrap {
   private String id;
   private Integer status;
 
-  @DBRef
-  private Post post;
-  @DBRef
-  private User user;
+
+  private String post;
+
+  private String user;
 
 
 }

--- a/src/main/java/com/example/backend_webflux/handler/PostHandler.java
+++ b/src/main/java/com/example/backend_webflux/handler/PostHandler.java
@@ -101,7 +101,7 @@ public class PostHandler {
                 Post p = new Post();
                 BeanUtils.copyProperties(d, p);
                 p.setStatus(0);
-                p.setUser(user);
+                p.setUser(user.getId());
                 return postRepository.insert(p);
               })
         );

--- a/src/main/java/com/example/backend_webflux/handler/ScrapHandler.java
+++ b/src/main/java/com/example/backend_webflux/handler/ScrapHandler.java
@@ -38,7 +38,7 @@ public class ScrapHandler {
     String userId = request.pathVariable("userId");
 
     Flux<Scrap> scraps = userRepository.findById(userId)
-        .flatMapMany(scrapRepository::findByUser)
+        .flatMapMany(user -> scrapRepository.findByUser(user.getId()))
         ;
 
     return ServerResponse.ok()
@@ -56,9 +56,9 @@ public class ScrapHandler {
             .flatMap(user -> postRepository.findById(d1.getPostId())
                 .flatMap(post -> {
                   Scrap s = new Scrap();
-                  s.setUser(user);
+                  s.setUser(user.getId());
                   s.setStatus(0);
-                  s.setPost(post);
+                  s.setPost(post.getId());
                   return scrapRepository.insert(s);
                 })
             )

--- a/src/main/java/com/example/backend_webflux/repository/PostRepository.java
+++ b/src/main/java/com/example/backend_webflux/repository/PostRepository.java
@@ -11,6 +11,6 @@ public interface PostRepository extends ReactiveMongoRepository<Post, String> {
 
   Flux<Post> findByTitleContains(String title, Pageable pageable);
 
-  Flux<Post> findByUserId(String userId);
+  Flux<Post> findByUser(String user);
 
 }

--- a/src/main/java/com/example/backend_webflux/repository/ScrapRepository.java
+++ b/src/main/java/com/example/backend_webflux/repository/ScrapRepository.java
@@ -12,7 +12,7 @@ public interface ScrapRepository extends ReactiveMongoRepository<Scrap, String> 
 
   
 
-  Mono<Scrap> findByPost(Post p);
+  Mono<Scrap> findByPost(String p);
 
-  Flux<Scrap> findByUser(User u);
+  Flux<Scrap> findByUser(String u);
 }

--- a/src/main/java/com/example/backend_webflux/router/PostRouter.java
+++ b/src/main/java/com/example/backend_webflux/router/PostRouter.java
@@ -55,10 +55,10 @@ public class PostRouter {
 //  }
 
   @Bean
-  @CreatePostByUserIdApiInfo
-  public RouterFunction<ServerResponse> createPostByUserIdRouter(PostHandler postHandler) {
+  @CreatePostApiInfo
+  public RouterFunction<ServerResponse> createPostRouter(PostHandler postHandler) {
     return RouterFunctions
-        .route(POST("/api/post/{userId}/user")
+        .route(POST("/api/post")
             , postHandler::createPostByUserId);
   }
 


### PR DESCRIPTION
## 설명

기존에는 @DBRef 어노테이션으로 관계 설정을 하려 했으나, 이 방법은 추천되는 방법이 아님을 타 깃헙 레포에서 확인.

이후, 각  collection에서 관계를 맺고자 하는 collection의 id를 field로 갖고 있는 것으로 수정.

따라서, front에서 요청을 2번 보내야 함.
> @DBRef 어노테이션으로 요청 한 번에 2개의 collection의 데이터를 줄 수 있게 하려고 했으나, 이 방법은 필자가 생각하기에 그닥 좋은 방법은 아닌 듯 하다. 그래서 관계를 맺고 있는 collection의 id를 알려주어 이 collection에 해당하는 router로 front에서 요청을 한 번 더 보내는 방식으로 구현하였다.